### PR TITLE
Fix memory leak in node set initialization

### DIFF
--- a/src/provider/provider_os_memory.c
+++ b/src/provider/provider_os_memory.c
@@ -264,7 +264,8 @@ err_free_bitmaps:
         hwloc_bitmap_free(out_nodeset[i]);
     }
 err_free_list:
-    umf_ba_global_free(*out_nodeset);
+    // free the array of bitmap pointers
+    umf_ba_global_free(out_nodeset);
     os_provider->nodeset_len = 0;
     return UMF_RESULT_ERROR_OUT_OF_HOST_MEMORY;
 }


### PR DESCRIPTION
## Summary
- fix freeing of the nodeset array when initialization fails
- clarify cleanup comment

## Testing
- `cmake -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j $(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684818eee23c83219dc91053e08360ba

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lplewa/unified-memory-framework/2)
<!-- Reviewable:end -->
