### PR TITLE
Fix wording for advanced examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,7 @@ For a quick introduction to UMF usage, please see
 [examples](https://oneapi-src.github.io/unified-memory-framework/examples.html)
 documentation, which includes the code of the
 [basic example](https://github.com/oneapi-src/unified-memory-framework/blob/main/examples/basic/basic.c).
-The are also more advanced that allocates USM memory from the
-[Level Zero device](https://github.com/oneapi-src/unified-memory-framework/blob/main/examples/level_zero_shared_memory/level_zero_shared_memory.c)
-using the Level Zero API and UMF Level Zero memory provider and [CUDA device](https://github.com/oneapi-src/unified-memory-framework/blob/main/examples/cuda_shared_memory/cuda_shared_memory.c)
-using the CUDA API and UMF CUDA memory provider.
+There are also more advanced examples that allocate USM memory from the [Level Zero device](examples/level_zero_shared_memory/level_zero_shared_memory.c) using the Level Zero API and UMF Level Zero memory provider and [CUDA device](examples/cuda_shared_memory/cuda_shared_memory.c) using the CUDA API and UMF CUDA memory provider.
 
 ## Build
 


### PR DESCRIPTION
## Summary
- fix the sentence describing the advanced Level Zero and CUDA examples

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68482380370883218c425185b662af46

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lplewa/unified-memory-framework/3)
<!-- Reviewable:end -->
