### PR TITLE
Fix incorrect allocation status check in examples

### DIFF
--- a/examples/cuda_shared_memory/cuda_shared_memory.c
+++ b/examples/cuda_shared_memory/cuda_shared_memory.c
@@ -146,7 +146,7 @@ int main(void) {
 
     // Allocate some memory from the pool
     int *ptr = umfPoolMalloc(cu_disjoint_memory_pool, sizeof(int));
-    if (res != UMF_RESULT_SUCCESS) {
+    if (ptr == NULL) {
         fprintf(stderr, "Failed to allocate memory from the memory pool!\n");
         ret = -1;
         goto memory_pool_destroy;

--- a/examples/level_zero_shared_memory/level_zero_shared_memory.c
+++ b/examples/level_zero_shared_memory/level_zero_shared_memory.c
@@ -157,7 +157,7 @@ int main(void) {
 
     // Allocate some memory from the pool
     int *ptr = umfPoolMalloc(ze_disjoint_memory_pool, sizeof(int));
-    if (res != UMF_RESULT_SUCCESS) {
+    if (ptr == NULL) {
         fprintf(stderr, "Failed to allocate memory from the memory pool!\n");
         ret = -1;
         goto memory_pool_destroy;


### PR DESCRIPTION
## Summary
- fix allocation verification in CUDA shared memory example
- fix allocation verification in Level Zero shared memory example

## Testing
- `cmake -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j $(nproc)`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684823820ae88321a7682000c3ba91c7

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lplewa/unified-memory-framework/4)
<!-- Reviewable:end -->
