### PR TITLE
Fix README benchmark note

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ In order to build the benchmark, the `UMF_BUILD_BENCHMARKS` CMake configuration 
 
 UMF also provides multithreaded benchmarks that can be enabled by setting both
 `UMF_BUILD_BENCHMARKS` and `UMF_BUILD_BENCHMARKS_MT` CMake
-configuration flags to `ON`. Multithreaded benchmarks require a C++ support.
+configuration flags to `ON`. Multithreaded benchmarks require C++ support.
 
 The Scalable Pool requirements can be found in the relevant 'Memory Pool
 managers' section below.


### PR DESCRIPTION
## Summary
- clarify that multithreaded benchmarks require C++ support

## Testing
- `grep -n "Multithreaded benchmarks require" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_68482390d4d88321bcce1a3125c874d0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lplewa/unified-memory-framework/6)
<!-- Reviewable:end -->
