### PR TITLE
Fix Windows atexit function pointer

### DIFF
--- a/src/libumf_windows.c
+++ b/src/libumf_windows.c
@@ -33,6 +33,8 @@ void libumfInit(void) {
 
 INIT_ONCE init_once_flag = INIT_ONCE_STATIC_INIT;
 
+static void umfTearDownWrapper(void) { (void)umfTearDown(); }
+
 BOOL CALLBACK initOnceCb(PINIT_ONCE InitOnce, PVOID Parameter,
                          PVOID *lpContext) {
     (void)InitOnce;  // unused
@@ -40,7 +42,7 @@ BOOL CALLBACK initOnceCb(PINIT_ONCE InitOnce, PVOID Parameter,
     (void)lpContext; // unused
 
     umf_result_t ret = umfInit();
-    atexit(umfTearDown);
+    atexit(umfTearDownWrapper);
     return (ret == UMF_RESULT_SUCCESS) ? TRUE : FALSE;
 }
 


### PR DESCRIPTION
## Summary
- fix incompatible function pointer call in `libumf_windows.c`
- wrap `umfTearDown` in a `void` function before passing to `atexit`

## Testing
- `cmake -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j $(nproc)`
- `ctest --output-on-failure -j $(nproc)`


------
https://chatgpt.com/codex/tasks/task_e_6863c9afddec832188a780a041774d05